### PR TITLE
Build CLI fat JAR and draft releases in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, native-image]
   push:
     branches: [main, native-image]
 
@@ -99,9 +99,9 @@ jobs:
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      # - name: Check that workflows are up to date
-      #   shell: bash
-      #   run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+      - name: Check that workflows are up to date
+        shell: bash
+        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Test
         shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [2.12.20, 3.6.3]
-        java: [temurin@11, temurin@17, graal_graalvm@21]
+        java: [temurin@11, temurin@17, temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)
@@ -54,14 +54,12 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - name: Setup GraalVM (graal_graalvm@21)
-        if: matrix.java == 'graal_graalvm@21'
-        uses: graalvm/setup-graalvm@v1
+      - name: Setup Java (temurin@21)
+        if: matrix.java == 'temurin@21'
+        uses: actions/setup-java@v4
         with:
+          distribution: temurin
           java-version: 21
-          distribution: graalvm
-          components: native-image
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: sbt
 
       - name: Setup sbt
@@ -74,25 +72,25 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' test scripted
 
       - name: Build CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
+        if: matrix.java == 'temurin@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         env:
           FIND_UNUSED_CLI_ASSEMBLY_JAR_NAME: find-unused-assembly.jar
         run: sbt '++ ${{ matrix.scala }}' cli/assembly
 
       - name: Copy CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
+        if: matrix.java == 'temurin@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         run: |
           mkdir -p cli/artifacts/
           cp cli/target/scala-${{ matrix.scala }}/find-unused-assembly.jar cli/artifacts/${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
 
       - name: Attest CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
+        if: matrix.java == 'temurin@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: cli/artifacts/${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
 
       - name: Upload CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
+        if: matrix.java == 'temurin@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
@@ -108,7 +106,7 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         scala: [3.6.3]
-        java: [graal_graalvm@21]
+        java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout current branch (full)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           - macos-13
           - macos-latest
           - windows-latest
-        scala: [2.12.20, 3.6.3]
-        java: [temurin@11, temurin@17, graal_graalvm@21]
+        scala: [3.6.3]
+        java: [graal_graalvm@21]
         include:
           - os: ubuntu-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
@@ -76,22 +76,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: Setup Java (temurin@17)
-        if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: sbt
 
       - name: Setup GraalVM (graal_graalvm@21)
         if: matrix.java == 'graal_graalvm@21'
@@ -144,7 +128,6 @@ jobs:
   release:
     name: Release
     needs: [build]
-    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -187,7 +170,7 @@ jobs:
           name: ${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
-      - name: Copy artifacts
+      - name: Copy CLI
         run: |
           cp cli/artifacts/${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux
           cp cli/artifacts/${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux-arm
@@ -195,14 +178,18 @@ jobs:
           cp cli/artifacts/${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac-arm
           cp cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
 
-      - name: Create Release
-        uses: softprops/action-gh-release@v2
+      - name: List pre-compression
+        run: ls -l cli/artifacts/
+
+      - name: Pack CLI
+        uses: crazy-max/ghaction-upx@v3
         with:
-          draft: true
           files: |
             cli/artifacts/find-unused-linux
             cli/artifacts/find-unused-linux-arm
             cli/artifacts/find-unused-mac
             cli/artifacts/find-unused-mac-arm
             cli/artifacts/find-unused-windows.exe
-          fail_on_unmatched_files: true
+
+      - name: List post-compression
+        run: ls -l cli/artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,6 +142,7 @@ jobs:
   release:
     name: Release
     needs: [build]
+    if: startsWith(github.ref, 'refs/tags/v')
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -178,9 +179,6 @@ jobs:
         with:
           name: find-unused-windows.exe
           path: cli/artifacts/
-
-      - name: List artifacts
-        run: ls -l cli/artifacts/
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [main, native-image]
+    branches: [main, cli-assembly]
   push:
-    branches: [main, native-image]
+    branches: [main, cli-assembly]
     tags: [v*]
 
 permissions:
@@ -28,50 +28,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-          - macos-13
-          - macos-latest
-          - windows-latest
+        os: [ubuntu-latest]
         scala: [2.12.20, 3.6.3]
         java: [temurin@11, temurin@17, graal_graalvm@21]
-        include:
-          - os: ubuntu-latest
-            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          - os: ubuntu-24.04-arm
-            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          - os: macos-13
-            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          - os: macos-latest
-            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          - os: windows-latest
-            cli_input_path: cli/target/graalvm-native-image/find-unused-cli.exe
-            cli_output_name: ${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
     runs-on: ${{ matrix.os }}
     steps:
-      - name: Ignore line ending differences in git
-        if: contains(runner.os, 'windows')
-        shell: bash
-        run: git config --global core.autocrlf false
-
-      - name: Configure pagefile for Windows
-        if: contains(runner.os, 'windows')
-        uses: al-cheb/configure-pagefile-action@v1.4
-        with:
-          minimum-size: 2GB
-          maximum-size: 8GB
-          disk-root: 'C:'
-
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -107,36 +68,34 @@ jobs:
         uses: sbt/setup-sbt@v1
 
       - name: Check that workflows are up to date
-        shell: bash
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
       - name: Test
-        shell: bash
         run: sbt '++ ${{ matrix.scala }}' test scripted
 
       - name: Build CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
-        shell: bash
-        run: sbt '++ ${{ matrix.scala }}' cli/GraalVMNativeImage/packageBin
+        env:
+          FIND_UNUSED_CLI_ASSEMBLY_JAR_NAME: find-unused-assembly.jar
+        run: sbt '++ ${{ matrix.scala }}' cli/assembly
 
       - name: Copy CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
-        shell: bash
         run: |
           mkdir -p cli/artifacts/
-          cp ${{ matrix.cli_input_path }} ${{ matrix.cli_output_path }}
+          cp cli/target/scala-${{ matrix.scala }}/find-unused-assembly.jar cli/artifacts/${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
 
       - name: Attest CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: cli/artifacts/${{ matrix.cli_output_name }}
+          subject-path: cli/artifacts/${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
 
       - name: Upload CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.cli_output_name }}
+          name: ${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
           if-no-files-found: error
           retention-days: 2
@@ -157,74 +116,18 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Download artifact (linux)
+      - name: Download CLI
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          path: cli/artifacts/
-
-      - name: Download artifact (linux-arm)
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          path: cli/artifacts/
-
-      - name: Download artifact (mac)
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          path: cli/artifacts/
-
-      - name: Download artifact (mac-arm)
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-          path: cli/artifacts/
-
-      - name: Download artifact (windows)
-        uses: actions/download-artifact@v4
-        with:
-          name: ${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+          name: ${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
       - name: Copy CLI
-        run: |
-          cp cli/artifacts/${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux
-          chmod +x cli/artifacts/find-unused-linux
-          cp cli/artifacts/${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux-arm
-          chmod +x cli/artifacts/find-unused-linux-arm
-          cp cli/artifacts/${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac
-          chmod +x cli/artifacts/find-unused-mac
-          cp cli/artifacts/${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac-arm
-          chmod +x cli/artifacts/find-unused-mac-arm
-          cp cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
-          chmod +x cli/artifacts/find-unused-windows.exe
-
-      - name: Pack CLI
-        uses: crazy-max/ghaction-upx@v3
-        with:
-          files: |
-            cli/artifacts/find-unused-linux
-            cli/artifacts/find-unused-linux-arm
-            cli/artifacts/find-unused-windows.exe
-
-      - name: Compress CLI
-        run: |
-          cd cli/artifacts/
-          tar -cvzf find-unused-linux.tar.gz find-unused-linux
-          tar -cvzf find-unused-linux-arm.tar.gz find-unused-linux-arm
-          tar -cvzf find-unused-mac.tar.gz find-unused-mac
-          tar -cvzf find-unused-mac-arm.tar.gz find-unused-mac-arm
-          tar -cvzf find-unused-windows.exe.tar.gz find-unused-windows.exe
+        run: cp cli/artifacts/${{ format('find-unused-{0}.jar', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused.jar
 
       - name: Create Release
         uses: softprops/action-gh-release@v2
         with:
           draft: true
-          files: |
-            cli/artifacts/find-unused-linux.tar.gz
-            cli/artifacts/find-unused-linux-arm.tar.gz
-            cli/artifacts/find-unused-mac.tar.gz
-            cli/artifacts/find-unused-mac-arm.tar.gz
-            cli/artifacts/find-unused-windows.exe.tar.gz
+          files: cli/artifacts/find-unused.jar
           fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,27 +26,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os:
-          - ubuntu-latest
-          - ubuntu-24.04-arm
-          - macos-13
-          - macos-latest
-          - windows-latest
+        os: [windows-latest]
         scala: [2.12.20, 3.6.3]
-        java: [temurin@11, temurin@17, graal_graalvm@21]
+        java: [graal_graalvm@21]
         include:
-          - os: ubuntu-latest
-            cli_name: find-unused-linux
-            cli_path: cli/artifacts/find-unused-linux
-          - os: ubuntu-24.04-arm
-            cli_name: find-unused-linux-arm
-            cli_path: cli/artifacts/find-unused-linux-arm
-          - os: macos-13
-            cli_name: find-unused-mac
-            cli_path: cli/artifacts/find-unused-mac
-          - os: macos-latest
-            cli_name: find-unused-mac-arm
-            cli_path: cli/artifacts/find-unused-mac-arm
           - os: windows-latest
             cli_name: find-unused-windows
             cli_path: cli/artifacts/find-unused-windows
@@ -69,22 +52,6 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-
-      - name: Setup Java (temurin@11)
-        if: matrix.java == 'temurin@11'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 11
-          cache: sbt
-
-      - name: Setup Java (temurin@17)
-        if: matrix.java == 'temurin@17'
-        uses: actions/setup-java@v4
-        with:
-          distribution: temurin
-          java-version: 17
-          cache: sbt
 
       - name: Setup GraalVM (graal_graalvm@21)
         if: matrix.java == 'graal_graalvm@21'
@@ -117,6 +84,7 @@ jobs:
         shell: bash
         run: |
           mkdir -p cli/artifacts
+          ls -l cli/target/graalvm-native-image/
           cp cli/target/graalvm-native-image/find-unused-cli ${{ matrix.cli_path }}
 
       - name: Attest CLI

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
   pull_request:
     branches: [main]
   push:
-    branches: [main]
+    branches: [main, native-image]
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -22,11 +22,29 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-13
+          - macos-latest
+          - windows-latest
         scala: [2.12.20, 3.6.3]
-        java: [temurin@11, temurin@17, temurin@21]
+        java: [temurin@11, temurin@17, graal_graalvm@21]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Ignore line ending differences in git
+        if: contains(runner.os, 'windows')
+        shell: bash
+        run: git config --global core.autocrlf false
+
+      - name: Configure pagefile for Windows
+        if: contains(runner.os, 'windows')
+        uses: al-cheb/configure-pagefile-action@v1.4
+        with:
+          minimum-size: 2GB
+          maximum-size: 8GB
+          disk-root: 'C:'
+
       - name: Checkout current branch (full)
         uses: actions/checkout@v4
         with:
@@ -48,19 +66,28 @@ jobs:
           java-version: 17
           cache: sbt
 
-      - name: Setup Java (temurin@21)
-        if: matrix.java == 'temurin@21'
-        uses: actions/setup-java@v4
+      - name: Setup GraalVM (graal_graalvm@21)
+        if: matrix.java == 'graal_graalvm@21'
+        uses: graalvm/setup-graalvm@v1
         with:
-          distribution: temurin
           java-version: 21
+          distribution: graalvm
+          components: native-image
+          github-token: ${{ secrets.GITHUB_TOKEN }}
           cache: sbt
 
       - name: Setup sbt
         uses: sbt/setup-sbt@v1
 
-      - name: Check that workflows are up to date
-        run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
+      # - name: Check that workflows are up to date
+      #   shell: bash
+      #   run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
-      - name: test
+      - name: Test
+        shell: bash
         run: sbt '++ ${{ matrix.scala }}' test scripted
+
+      - name: Build CLI
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
+        shell: bash
+        run: sbt '++ ${{ matrix.scala }}' cli/GraalVMNativeImage/packageBin

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -143,7 +143,7 @@ jobs:
         with:
           name: find-unused-linux
           path: cli/artifacts/
-          if-no-file-found: error
+          if-no-files-found: error
           retention-days: 2
 
       - name: Upload CLI (ubuntu-24.04-arm)
@@ -152,7 +152,7 @@ jobs:
         with:
           name: find-unused-linux-arm
           path: cli/artifacts/
-          if-no-file-found: error
+          if-no-files-found: error
           retention-days: 2
 
       - name: Upload CLI (macos-13)
@@ -161,7 +161,7 @@ jobs:
         with:
           name: find-unused-mac
           path: cli/artifacts/
-          if-no-file-found: error
+          if-no-files-found: error
           retention-days: 2
 
       - name: Upload CLI (macos-latest)
@@ -170,7 +170,7 @@ jobs:
         with:
           name: find-unused-mac-arm
           path: cli/artifacts/
-          if-no-file-found: error
+          if-no-files-found: error
           retention-days: 2
 
       - name: Upload CLI (windows-latest)
@@ -179,5 +179,5 @@ jobs:
         with:
           name: find-unused-windows
           path: cli/artifacts/
-          if-no-file-found: error
+          if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ on:
   push:
     branches: [main, native-image]
 
+permissions:
+  id-token: write
+  attestations: write
+
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,6 +34,22 @@ jobs:
           - windows-latest
         scala: [2.12.20, 3.6.3]
         java: [temurin@11, temurin@17, graal_graalvm@21]
+        include:
+          - os: ubuntu-latest
+            cli_name: find-unused-linux
+            cli_path: cli/artifacts/find-unused-linux
+          - os: ubuntu-24.04-arm
+            cli_name: find-unused-linux-arm
+            cli_path: cli/artifacts/find-unused-linux-arm
+          - os: macos-13
+            cli_name: find-unused-mac
+            cli_path: cli/artifacts/find-unused-mac
+          - os: macos-latest
+            cli_name: find-unused-mac-arm
+            cli_path: cli/artifacts/find-unused-mac-arm
+          - os: windows-latest
+            cli_name: find-unused-windows
+            cli_path: cli/artifacts/find-unused-windows
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -96,88 +112,24 @@ jobs:
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' cli/GraalVMNativeImage/packageBin
 
-      - name: Copy CLI (ubuntu-latest)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-latest'
+      - name: Copy CLI
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         shell: bash
         run: |
           mkdir -p cli/artifacts
-          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux
-
-      - name: Copy CLI (ubuntu-24.04-arm)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-24.04-arm'
-        shell: bash
-        run: |
-          mkdir -p cli/artifacts
-          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux-arm
-
-      - name: Copy CLI (macos-13)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-13'
-        shell: bash
-        run: |
-          mkdir -p cli/artifacts
-          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac
-
-      - name: Copy CLI (macos-latest)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-latest'
-        shell: bash
-        run: |
-          mkdir -p cli/artifacts
-          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac-arm
-
-      - name: Copy CLI (windows-latest)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'windows-latest'
-        shell: bash
-        run: |
-          mkdir -p cli/artifacts
-          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-windows
+          cp cli/target/graalvm-native-image/find-unused-cli ${{ matrix.cli_path }}
 
       - name: Attest CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: cli/artifacts/*
+          subject-path: cli/artifacts/${{ matrix.cli_name }}
 
-      - name: Upload CLI (ubuntu-latest)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-latest'
+      - name: Upload CLI
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         uses: actions/upload-artifact@v4
         with:
-          name: find-unused-linux
-          path: cli/artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-      - name: Upload CLI (ubuntu-24.04-arm)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-24.04-arm'
-        uses: actions/upload-artifact@v4
-        with:
-          name: find-unused-linux-arm
-          path: cli/artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-      - name: Upload CLI (macos-13)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-13'
-        uses: actions/upload-artifact@v4
-        with:
-          name: find-unused-mac
-          path: cli/artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-      - name: Upload CLI (macos-latest)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: find-unused-mac-arm
-          path: cli/artifacts/
-          if-no-files-found: error
-          retention-days: 2
-
-      - name: Upload CLI (windows-latest)
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'windows-latest'
-        uses: actions/upload-artifact@v4
-        with:
-          name: find-unused-windows
+          name: ${{ matrix.cli_name }}
           path: cli/artifacts/
           if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,29 +95,40 @@ jobs:
       - name: Copy CLI (ubuntu-latest)
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-latest'
         shell: bash
-        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux
+        run: |
+          mkdir -p cli/artifacts
+          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux
 
       - name: Copy CLI (ubuntu-24.04-arm)
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-24.04-arm'
         shell: bash
-        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux-arm
+        run: |
+          mkdir -p cli/artifacts
+          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux-arm
 
       - name: Copy CLI (macos-13)
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-13'
         shell: bash
-        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac
+        run: |
+          mkdir -p cli/artifacts
+          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac
 
       - name: Copy CLI (macos-latest)
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-latest'
         shell: bash
-        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac-arm
+        run: |
+          mkdir -p cli/artifacts
+          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac-arm
 
       - name: Copy CLI (windows-latest)
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'windows-latest'
         shell: bash
-        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-windows
+        run: |
+          mkdir -p cli/artifacts
+          cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-windows
 
       - name: Attest CLI
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: cli/artifacts/*

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,3 +91,78 @@ jobs:
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' cli/GraalVMNativeImage/packageBin
+
+      - name: Copy CLI (ubuntu-latest)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-latest'
+        shell: bash
+        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux
+
+      - name: Copy CLI (ubuntu-24.04-arm)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-24.04-arm'
+        shell: bash
+        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-linux-arm
+
+      - name: Copy CLI (macos-13)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-13'
+        shell: bash
+        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac
+
+      - name: Copy CLI (macos-latest)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-latest'
+        shell: bash
+        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-mac-arm
+
+      - name: Copy CLI (windows-latest)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'windows-latest'
+        shell: bash
+        run: cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-windows
+
+      - name: Attest CLI
+        uses: actions/attest-build-provenance@v2
+        with:
+          subject-path: cli/artifacts/*
+
+      - name: Upload CLI (ubuntu-latest)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: find-unused-linux
+          path: cli/artifacts/
+          if-no-file-found: error
+          retention-days: 2
+
+      - name: Upload CLI (ubuntu-24.04-arm)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'ubuntu-24.04-arm'
+        uses: actions/upload-artifact@v4
+        with:
+          name: find-unused-linux-arm
+          path: cli/artifacts/
+          if-no-file-found: error
+          retention-days: 2
+
+      - name: Upload CLI (macos-13)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-13'
+        uses: actions/upload-artifact@v4
+        with:
+          name: find-unused-mac
+          path: cli/artifacts/
+          if-no-file-found: error
+          retention-days: 2
+
+      - name: Upload CLI (macos-latest)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'macos-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: find-unused-mac-arm
+          path: cli/artifacts/
+          if-no-file-found: error
+          retention-days: 2
+
+      - name: Upload CLI (windows-latest)
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && matrix.os == 'windows-latest'
+        uses: actions/upload-artifact@v4
+        with:
+          name: find-unused-windows
+          path: cli/artifacts/
+          if-no-file-found: error
+          retention-days: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,10 +173,15 @@ jobs:
       - name: Copy CLI
         run: |
           cp cli/artifacts/${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux
+          chmod +x cli/artifacts/find-unused-linux
           cp cli/artifacts/${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux-arm
+          chmod +x cli/artifacts/find-unused-linux-arm
           cp cli/artifacts/${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac
+          chmod +x cli/artifacts/find-unused-mac
           cp cli/artifacts/${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac-arm
+          chmod +x cli/artifacts/find-unused-mac-arm
           cp cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
+          chmod +x cli/artifacts/find-unused-windows.exe
 
       - name: List pre-compression
         run: ls -l cli/artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,8 +34,8 @@ jobs:
           - macos-13
           - macos-latest
           - windows-latest
-        scala: [3.6.3]
-        java: [graal_graalvm@21]
+        scala: [2.12.20, 3.6.3]
+        java: [temurin@11, temurin@17, graal_graalvm@21]
         include:
           - os: ubuntu-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
@@ -76,6 +76,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
 
       - name: Setup GraalVM (graal_graalvm@21)
         if: matrix.java == 'graal_graalvm@21'
@@ -128,6 +144,7 @@ jobs:
   release:
     name: Release
     needs: [build]
+    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -183,9 +200,6 @@ jobs:
           cp cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
           chmod +x cli/artifacts/find-unused-windows.exe
 
-      - name: List pre-compression
-        run: ls -l cli/artifacts/
-
       - name: Pack CLI
         uses: crazy-max/ghaction-upx@v3
         with:
@@ -202,5 +216,14 @@ jobs:
           tar -cvzf cli/artifacts/find-unused-mac-arm.tar.gz cli/artifacts/find-unused-mac-arm
           tar -cvzf cli/artifacts/find-unused-windows.exe.tar.gz cli/artifacts/find-unused-windows.exe
 
-      - name: List post-compression
-        run: ls -l cli/artifacts/
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: |
+            cli/artifacts/find-unused-linux.tar.gz
+            cli/artifacts/find-unused-linux-arm.tar.gz
+            cli/artifacts/find-unused-mac.tar.gz
+            cli/artifacts/find-unused-mac-arm.tar.gz
+            cli/artifacts/find-unused-windows.exe.tar.gz
+          fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,8 +31,9 @@ jobs:
         java: [graal_graalvm@21]
         include:
           - os: windows-latest
-            cli_name: find-unused-windows
-            cli_path: cli/artifacts/find-unused-windows
+            cli_input_path: cli/target/graalvm-native-image/find-unused-cli.exe
+            cli_output_name: find-unused-windows.exe
+            cli_output_path: cli/artifacts/find-unused-windows.exe
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -85,19 +86,19 @@ jobs:
         run: |
           mkdir -p cli/artifacts
           ls -l cli/target/graalvm-native-image/
-          cp cli/target/graalvm-native-image/find-unused-cli ${{ matrix.cli_path }}
+          cp ${{ matrix.cli_input_path }} ${{ matrix.cli_output_path }}
 
       - name: Attest CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         uses: actions/attest-build-provenance@v2
         with:
-          subject-path: cli/artifacts/${{ matrix.cli_name }}
+          subject-path: cli/artifacts/${{ matrix.cli_output_name }}
 
       - name: Upload CLI
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.cli_name }}
+          name: ${{ matrix.cli_output_name }}
           path: cli/artifacts/
           if-no-files-found: error
           retention-days: 2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,10 +26,31 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [windows-latest]
+        os:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+          - macos-13
+          - macos-latest
+          - windows-latest
         scala: [2.12.20, 3.6.3]
-        java: [graal_graalvm@21]
+        java: [temurin@11, temurin@17, graal_graalvm@21]
         include:
+          - os: ubuntu-latest
+            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
+            cli_output_name: find-unused-linux
+            cli_output_path: cli/artifacts/find-unused-linux
+          - os: ubuntu-24.04-arm
+            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
+            cli_output_name: find-unused-linux-arm
+            cli_output_path: cli/artifacts/find-unused-linux-arm
+          - os: macos-13
+            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
+            cli_output_name: find-unused-mac
+            cli_output_path: cli/artifacts/find-unused-mac
+          - os: macos-latest
+            cli_input_path: cli/target/graalvm-native-image/find-unused-cli
+            cli_output_name: find-unused-mac-arm
+            cli_output_path: cli/artifacts/find-unused-mac-arm
           - os: windows-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli.exe
             cli_output_name: find-unused-windows.exe
@@ -53,6 +74,22 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Setup Java (temurin@11)
+        if: matrix.java == 'temurin@11'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 11
+          cache: sbt
+
+      - name: Setup Java (temurin@17)
+        if: matrix.java == 'temurin@17'
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: sbt
 
       - name: Setup GraalVM (graal_graalvm@21)
         if: matrix.java == 'graal_graalvm@21'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,24 @@ jobs:
         include:
           - os: ubuntu-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_name: ${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: ubuntu-24.04-arm
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_name: ${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: macos-13
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_name: ${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: macos-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: ${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_name: ${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: windows-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli.exe
-            cli_output_name: ${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
-            cli_output_path: cli/artifacts/${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_name: ${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -159,40 +159,40 @@ jobs:
       - name: Download artifact (linux)
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+          name: ${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
       - name: Download artifact (linux-arm)
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+          name: ${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
       - name: Download artifact (mac)
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+          name: ${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
       - name: Download artifact (mac-arm)
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+          name: ${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
       - name: Download artifact (windows)
         uses: actions/download-artifact@v4
         with:
-          name: ${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+          name: ${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
       - name: Copy artifacts
         run: |
-          cp cli/artifacts/${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux
-          cp cli/artifacts/${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux-arm
-          cp cli/artifacts/${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac
-          cp cli/artifacts/${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac-arm
-          cp cli/artifacts/${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
+          cp cli/artifacts/${{ format('find-unused-linux-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux
+          cp cli/artifacts/${{ format('find-unused-linux-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux-arm
+          cp cli/artifacts/${{ format('find-unused-mac-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac
+          cp cli/artifacts/${{ format('find-unused-mac-arm-{0}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac-arm
+          cp cli/artifacts/${{ format('find-unused-windows-{0}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ on:
     branches: [main, native-image]
   push:
     branches: [main, native-image]
+    tags: [v*]
 
 permissions:
   id-token: write

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,7 @@ jobs:
         if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
         shell: bash
         run: |
-          mkdir -p cli/artifacts
-          ls -l cli/target/graalvm-native-image/
+          mkdir -p cli/artifacts/
           cp ${{ matrix.cli_input_path }} ${{ matrix.cli_output_path }}
 
       - name: Attest CLI
@@ -139,3 +138,46 @@ jobs:
           path: cli/artifacts/
           if-no-files-found: error
           retention-days: 2
+
+  release:
+    name: Release
+    needs: [build]
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+        scala: [3.6.3]
+        java: [graal_graalvm@21]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout current branch (full)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: find-unused-linux
+          path: cli/artifacts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: find-unused-linux-arm
+          path: cli/artifacts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: find-unused-mac
+          path: cli/artifacts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: find-unused-mac-arm
+          path: cli/artifacts/
+
+      - uses: actions/download-artifact@v4
+        with:
+          name: find-unused-windows.exe
+          path: cli/artifacts/
+
+      - name: List artifacts
+        run: ls -l cli/artifacts/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -181,3 +181,15 @@ jobs:
 
       - name: List artifacts
         run: ls -l cli/artifacts/
+
+      - name: Create Release
+        uses: softprops/action-gh-release@v2
+        with:
+          draft: true
+          files: |
+            cli/artifacts/find-unused-linux
+            cli/artifacts/find-unused-linux-arm
+            cli/artifacts/find-unused-mac
+            cli/artifacts/find-unused-mac-arm
+            cli/artifacts/find-unused-windows.exe
+          fail_on_unmatched_files: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -210,11 +210,12 @@ jobs:
 
       - name: Compress CLI
         run: |
-          tar -cvzf cli/artifacts/find-unused-linux.tar.gz cli/artifacts/find-unused-linux
-          tar -cvzf cli/artifacts/find-unused-linux-arm.tar.gz cli/artifacts/find-unused-linux-arm
-          tar -cvzf cli/artifacts/find-unused-mac.tar.gz cli/artifacts/find-unused-mac
-          tar -cvzf cli/artifacts/find-unused-mac-arm.tar.gz cli/artifacts/find-unused-mac-arm
-          tar -cvzf cli/artifacts/find-unused-windows.exe.tar.gz cli/artifacts/find-unused-windows.exe
+          cd cli/artifacts/
+          tar -cvzf find-unused-linux.tar.gz find-unused-linux
+          tar -cvzf find-unused-linux-arm.tar.gz find-unused-linux-arm
+          tar -cvzf find-unused-mac.tar.gz find-unused-mac
+          tar -cvzf find-unused-mac-arm.tar.gz find-unused-mac-arm
+          tar -cvzf find-unused-windows.exe.tar.gz find-unused-windows.exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,9 @@ on:
     tags: [v*]
 
 permissions:
-  id-token: write
   attestations: write
+  contents: write
+  id-token: write
 
 env:
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,24 +38,24 @@ jobs:
         include:
           - os: ubuntu-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: find-unused-linux
-            cli_output_path: cli/artifacts/find-unused-linux
+            cli_output_name: ${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: ubuntu-24.04-arm
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: find-unused-linux-arm
-            cli_output_path: cli/artifacts/find-unused-linux-arm
+            cli_output_name: ${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: macos-13
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: find-unused-mac
-            cli_output_path: cli/artifacts/find-unused-mac
+            cli_output_name: ${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: macos-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli
-            cli_output_name: find-unused-mac-arm
-            cli_output_path: cli/artifacts/find-unused-mac-arm
+            cli_output_name: ${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           - os: windows-latest
             cli_input_path: cli/target/graalvm-native-image/find-unused-cli.exe
-            cli_output_name: find-unused-windows.exe
-            cli_output_path: cli/artifacts/find-unused-windows.exe
+            cli_output_name: ${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
+            cli_output_path: cli/artifacts/${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
     runs-on: ${{ matrix.os }}
     steps:
       - name: Ignore line ending differences in git
@@ -114,25 +114,25 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' test scripted
 
       - name: Build CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         shell: bash
         run: sbt '++ ${{ matrix.scala }}' cli/GraalVMNativeImage/packageBin
 
       - name: Copy CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         shell: bash
         run: |
           mkdir -p cli/artifacts/
           cp ${{ matrix.cli_input_path }} ${{ matrix.cli_output_path }}
 
       - name: Attest CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         uses: actions/attest-build-provenance@v2
         with:
           subject-path: cli/artifacts/${{ matrix.cli_output_name }}
 
       - name: Upload CLI
-        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3'
+        if: matrix.java == 'graal_graalvm@21' && matrix.scala == '3.6.3' && github.event_name == 'push'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.cli_output_name }}
@@ -143,7 +143,7 @@ jobs:
   release:
     name: Release
     needs: [build]
-    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'
     strategy:
       matrix:
         os: [ubuntu-latest]
@@ -156,30 +156,43 @@ jobs:
         with:
           fetch-depth: 0
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifact (linux)
+        uses: actions/download-artifact@v4
         with:
-          name: find-unused-linux
+          name: ${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifact (linux-arm)
+        uses: actions/download-artifact@v4
         with:
-          name: find-unused-linux-arm
+          name: ${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifact (mac)
+        uses: actions/download-artifact@v4
         with:
-          name: find-unused-mac
+          name: ${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifact (mac-arm)
+        uses: actions/download-artifact@v4
         with:
-          name: find-unused-mac-arm
+          name: ${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
 
-      - uses: actions/download-artifact@v4
+      - name: Download artifact (windows)
+        uses: actions/download-artifact@v4
         with:
-          name: find-unused-windows.exe
+          name: ${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }}
           path: cli/artifacts/
+
+      - name: Copy artifacts
+        run: |
+          cp cli/artifacts/${{ format('find-unused-linux-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux
+          cp cli/artifacts/${{ format('find-unused-linux-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-linux-arm
+          cp cli/artifacts/${{ format('find-unused-mac-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac
+          cp cli/artifacts/${{ format('find-unused-mac-arm-{}', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-mac-arm
+          cp cli/artifacts/${{ format('find-unused-windows-{}.exe', startsWith(github.ref, 'refs/tags/v') && github.ref_name || github.sha) }} cli/artifacts/find-unused-windows.exe
 
       - name: Create Release
         uses: softprops/action-gh-release@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,9 +9,9 @@ name: Continuous Integration
 
 on:
   pull_request:
-    branches: [main, cli-assembly]
+    branches: [main]
   push:
-    branches: [main, cli-assembly]
+    branches: [main]
     tags: [v*]
 
 permissions:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -192,9 +192,15 @@ jobs:
           files: |
             cli/artifacts/find-unused-linux
             cli/artifacts/find-unused-linux-arm
-            cli/artifacts/find-unused-mac
-            cli/artifacts/find-unused-mac-arm
             cli/artifacts/find-unused-windows.exe
+
+      - name: Compress CLI
+        run: |
+          tar -cvzf cli/artifacts/find-unused-linux.tar.gz cli/artifacts/find-unused-linux
+          tar -cvzf cli/artifacts/find-unused-linux-arm.tar.gz cli/artifacts/find-unused-linux-arm
+          tar -cvzf cli/artifacts/find-unused-mac.tar.gz cli/artifacts/find-unused-mac
+          tar -cvzf cli/artifacts/find-unused-mac-arm.tar.gz cli/artifacts/find-unused-mac-arm
+          tar -cvzf cli/artifacts/find-unused-windows.exe.tar.gz cli/artifacts/find-unused-windows.exe
 
       - name: List post-compression
         run: ls -l cli/artifacts/

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -12,7 +12,7 @@ on: push
 jobs:
   delete-artifacts:
     name: Delete Artifacts
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/.github/workflows/clean.yml
+++ b/.github/workflows/clean.yml
@@ -12,7 +12,7 @@ on: push
 jobs:
   delete-artifacts:
     name: Delete Artifacts
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     env:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -102,15 +102,15 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
     } ++
     List(
       WorkflowStep.Run(List(s"ls -l $cliArtifacts"), name = Some("List artifacts")),
-      // WorkflowStep.Use(
-      //   ref = UseRef.Public("softprops", "action-gh-release", "v2"),
-      //   name = Some("Create Release"),
-      //   params = Map(
-      //     "draft" -> "true",
-      //     "files" -> githubOSes.map { case (_, short) => cliPath(short) }.mkString("\n"),
-      //     "fail_on_unmatched_files" -> "true",
-      //   ),
-      // )
+      WorkflowStep.Use(
+        ref = UseRef.Public("softprops", "action-gh-release", "v2"),
+        name = Some("Create Release"),
+        params = Map(
+          "draft" -> "true",
+          "files" -> githubOSes.map { case (_, short) => cliPath(short) }.mkString("\n"),
+          "fail_on_unmatched_files" -> "true",
+        ),
+      ),
     )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,14 +10,14 @@ lazy val scala36 = "3.6.3"
 ThisBuild / crossScalaVersions := Seq(scala2, scala36)
 
 val java21 = JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21")
-val javaVersions = Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"), java21)
+val javaVersions = Seq(/*JavaSpec.temurin("11"), JavaSpec.temurin("17"),*/ java21)
 
 val ubuntuLatest = "ubuntu-latest"
 val githubOSes = List(
-  ubuntuLatest -> "linux",
-  "ubuntu-24.04-arm" -> "linux-arm",
-  "macos-13" -> "mac",
-  "macos-latest" -> "mac-arm",
+  // ubuntuLatest -> "linux",
+  // "ubuntu-24.04-arm" -> "linux-arm",
+  // "macos-13" -> "mac",
+  // "macos-latest" -> "mac-arm",
   "windows-latest" -> "windows",
 )
 
@@ -50,6 +50,7 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Run(
     List(
       s"mkdir -p $cliArtifacts",
+      "ls -l cli/target/graalvm-native-image/",
       "cp cli/target/graalvm-native-image/find-unused-cli ${{ matrix.cli_path }}",
     ),
     name = Some("Copy CLI"),

--- a/build.sbt
+++ b/build.sbt
@@ -138,8 +138,8 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
         ),
       ),
       WorkflowStep.Run(
-        githubOSes.map { case (_, short) =>
-          val f = cliPath(short, cliNameNoSuffix)
+        s"cd $cliArtifacts" :: githubOSes.map { case (_, short) =>
+          val f = cliNameNoSuffix(short)
           s"tar -cvzf $f.tar.gz $f"
         },
         name = Some("Compress CLI"),

--- a/build.sbt
+++ b/build.sbt
@@ -36,7 +36,7 @@ ThisBuild / githubWorkflowOSes := githubOSes.map(_._1)
 ThisBuild / githubWorkflowJavaVersions := javaVersions
 ThisBuild / githubWorkflowArtifactUpload := false
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
-ThisBuild / githubWorkflowTargetBranches := Seq("main")
+ThisBuild / githubWorkflowTargetBranches := Seq("main", "native-image")
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
 def isJava(v: Int) = s"matrix.java == '${javaVersions.find(_.version == v.toString).get.render}'"

--- a/build.sbt
+++ b/build.sbt
@@ -62,7 +62,7 @@ ThisBuild / githubWorkflowBuild := Seq(
     params = Map(
       "name" -> s"find-unused-$short",
       "path" -> "cli/artifacts/",
-      "if-no-file-found" -> "error",
+      "if-no-files-found" -> "error",
       "retention-days" -> "2",
     )
   )

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,12 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Sbt(List("test", "scripted"), name = Some("Test")),
   WorkflowStep.Sbt(List("cli/GraalVMNativeImage/packageBin"), name = Some("Build CLI"), cond = Some(java21AndScala36)),
 ) ++ githubOSes.map { case (long, short) =>
+  val artifacts = "cli/artifacts"
   WorkflowStep.Run(
-    List(s"cp cli/target/graalvm-native-image/find-unused-cli cli/artifacts/find-unused-$short"),
+    List(
+      s"mkdir -p $artifacts",
+      s"cp cli/target/graalvm-native-image/find-unused-cli $artifacts/find-unused-$short",
+    ),
     name = Some(s"Copy CLI ($long)"),
     cond = Some(java21AndScala36 ++ " && " ++ isOS(long)),
   )
@@ -47,6 +51,7 @@ ThisBuild / githubWorkflowBuild := Seq(
   WorkflowStep.Use(
     ref = UseRef.Public("actions", "attest-build-provenance", "v2"),
     name = Some("Attest CLI"),
+    cond = Some(java21AndScala36),
     params = Map("subject-path" -> "cli/artifacts/*"),
   ),
 ) ++ githubOSes.map { case (long, short) =>

--- a/build.sbt
+++ b/build.sbt
@@ -12,10 +12,10 @@ ThisBuild / crossScalaVersions := Seq(scala2, scala36)
 val java21 = JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21")
 val javaVersions = Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"), java21)
 
+val isTag = "startsWith(github.ref, 'refs/tags/v')"
+
 val cliAssemblyJarNameEnv = "FIND_UNUSED_CLI_ASSEMBLY_JAR_NAME"
 val cliAssemblyJarNameSimple = "find-unused-assembly.jar"
-
-val isTag = "startsWith(github.ref, 'refs/tags/v')"
 
 val cliArtifacts = "cli/artifacts/"
 
@@ -33,7 +33,7 @@ ThisBuild / githubWorkflowPermissions := Some(Permissions.Specify(Map(
 ThisBuild / githubWorkflowJavaVersions := javaVersions
 ThisBuild / githubWorkflowArtifactUpload := false
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
-ThisBuild / githubWorkflowTargetBranches := Seq("main", "cli-assembly")
+ThisBuild / githubWorkflowTargetBranches := Seq("main")
 ThisBuild / githubWorkflowTargetTags := Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 

--- a/build.sbt
+++ b/build.sbt
@@ -32,7 +32,7 @@ def cliNameNoSuffix(osShort: String): String =
   "find-unused-" ++ osShort ++ cliExt(osShort)
 
 def cliName(osShort: String): String =
-  "${{ format('find-unused-" ++ osShort ++ "-{}" ++ cliExt(osShort) ++ "', " ++ isTag ++ " && github.ref_name || github.sha) }}"
+  "${{ format('find-unused-" ++ osShort ++ "-{0}" ++ cliExt(osShort) ++ "', " ++ isTag ++ " && github.ref_name || github.sha) }}"
 
 def cliPath(osShort: String, name: String => String = cliName): String =
   cliArtifacts ++ name(osShort)

--- a/build.sbt
+++ b/build.sbt
@@ -118,7 +118,13 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
     } ++
     List(
       WorkflowStep.Run(
-        githubOSes.map { case (_, short) => s"cp ${cliPath(short)} ${cliPath(short, cliNameNoSuffix)}" },
+        githubOSes.flatMap { case (_, short) =>
+          val f = cliPath(short, cliNameNoSuffix)
+          List(
+            s"cp ${cliPath(short)} $f",
+            s"chmod +x $f",
+          )
+        },
         name = Some("Copy CLI"),
       ),
       WorkflowStep.Run(

--- a/build.sbt
+++ b/build.sbt
@@ -38,8 +38,9 @@ def cliPath(osShort: String, name: String => String = cliName): String =
   cliArtifacts ++ name(osShort)
 
 ThisBuild / githubWorkflowPermissions := Some(Permissions.Specify(Map(
-  PermissionScope.IdToken -> PermissionValue.Write,
   PermissionScope.Attestations -> PermissionValue.Write,
+  PermissionScope.Contents -> PermissionValue.Write,
+  PermissionScope.IdToken -> PermissionValue.Write,
 )))
 ThisBuild / githubWorkflowBuildMatrixInclusions := githubOSes.map { case (long, short) =>
   MatrixInclude(

--- a/build.sbt
+++ b/build.sbt
@@ -7,10 +7,10 @@ lazy val tastyQueryDev = sys.env.get("TASTY_QUERY_DEVELOPMENT").exists(_ == "1")
 lazy val scala2 = "2.12.20"
 lazy val scala36 = "3.6.3"
 
-ThisBuild / crossScalaVersions := Seq(scala2, scala36)
+ThisBuild / crossScalaVersions := Seq(/*scala2,*/ scala36)
 
 val java21 = JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21")
-val javaVersions = Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"), java21)
+val javaVersions = Seq(/*JavaSpec.temurin("11"), JavaSpec.temurin("17"),*/ java21)
 
 val ubuntuLatest = "ubuntu-latest"
 val githubOSes = List(
@@ -106,7 +106,7 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
   oses = List(ubuntuLatest),
   javas = List(java21),
   scalas = List(scala36),
-  cond = Some("startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'"),
+  // cond = Some("startsWith(github.ref, 'refs/tags/v') && github.event_name == 'push'"),
   needs = List("build"),
   steps = List(WorkflowStep.CheckoutFull) ++
     githubOSes.map { case (_, short) =>
@@ -119,17 +119,32 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
     List(
       WorkflowStep.Run(
         githubOSes.map { case (_, short) => s"cp ${cliPath(short)} ${cliPath(short, cliNameNoSuffix)}" },
-        name = Some("Copy artifacts"),
+        name = Some("Copy CLI"),
+      ),
+      WorkflowStep.Run(
+        List(s"ls -l $cliArtifacts"),
+        name = Some("List pre-compression"),
       ),
       WorkflowStep.Use(
-        ref = UseRef.Public("softprops", "action-gh-release", "v2"),
-        name = Some("Create Release"),
+        ref = UseRef.Public("crazy-max", "ghaction-upx", "v3"),
+        name = some("Pack CLI"),
         params = Map(
-          "draft" -> "true",
           "files" -> githubOSes.map { case (_, short) => cliPath(short, cliNameNoSuffix) }.mkString("\n"),
-          "fail_on_unmatched_files" -> "true",
         ),
       ),
+      WorkflowStep.Run(
+        List(s"ls -l $cliArtifacts"),
+        name = Some("List post-compression"),
+      ),
+      // WorkflowStep.Use(
+      //   ref = UseRef.Public("softprops", "action-gh-release", "v2"),
+      //   name = Some("Create Release"),
+      //   params = Map(
+      //     "draft" -> "true",
+      //     "files" -> githubOSes.map { case (_, short) => cliPath(short, cliNameNoSuffix) }.mkString("\n"),
+      //     "fail_on_unmatched_files" -> "true",
+      //   ),
+      // ),
     )
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -10,14 +10,14 @@ lazy val scala36 = "3.6.3"
 ThisBuild / crossScalaVersions := Seq(scala2, scala36)
 
 val java21 = JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21")
-val javaVersions = Seq(/*JavaSpec.temurin("11"), JavaSpec.temurin("17"),*/ java21)
+val javaVersions = Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"), java21)
 
 val ubuntuLatest = "ubuntu-latest"
 val githubOSes = List(
-  // ubuntuLatest -> "linux",
-  // "ubuntu-24.04-arm" -> "linux-arm",
-  // "macos-13" -> "mac",
-  // "macos-latest" -> "mac-arm",
+  ubuntuLatest -> "linux",
+  "ubuntu-24.04-arm" -> "linux-arm",
+  "macos-13" -> "mac",
+  "macos-latest" -> "mac-arm",
   "windows-latest" -> "windows",
 )
 

--- a/build.sbt
+++ b/build.sbt
@@ -88,7 +88,7 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
   oses = List(ubuntuLatest),
   javas = List(java21),
   scalas = List(scala36),
-  // cond = Some("startsWith(github.ref, 'refs/tags/v')"),
+  cond = Some("startsWith(github.ref, 'refs/tags/v')"),
   needs = List("build"),
   steps = List(WorkflowStep.CheckoutFull) ++
     githubOSes.map { case (_, short) =>
@@ -101,7 +101,6 @@ ThisBuild / githubWorkflowAddedJobs += WorkflowJob(
       )
     } ++
     List(
-      WorkflowStep.Run(List(s"ls -l $cliArtifacts"), name = Some("List artifacts")),
       WorkflowStep.Use(
         ref = UseRef.Public("softprops", "action-gh-release", "v2"),
         name = Some("Create Release"),

--- a/build.sbt
+++ b/build.sbt
@@ -9,7 +9,7 @@ lazy val scala36 = "3.6.3"
 
 ThisBuild / crossScalaVersions := Seq(scala2, scala36)
 
-val java21 = JavaSpec.graalvm(Graalvm.Distribution("graalvm"), "21")
+val java21 = JavaSpec.temurin("21")
 val javaVersions = Seq(JavaSpec.temurin("11"), JavaSpec.temurin("17"), java21)
 
 val isTag = "startsWith(github.ref, 'refs/tags/v')"

--- a/build.sbt
+++ b/build.sbt
@@ -222,8 +222,9 @@ lazy val plugin = project.in(file("plugin"))
     scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
     libraryDependencies ++= Seq(
+      "dev.dirs" % "directories" % "26",
       ("io.get-coursier" %% "coursier" % "2.1.24").cross(CrossVersion.for3Use2_13)
-        .exclude("org.scala-lang.modules", "scala-xml_2.13")
+        .exclude("org.scala-lang.modules", "scala-xml_2.13"),
     ),
     cliClasspath := (cli / Runtime / fullClasspath).value.map(_.data),
     buildInfoKeys := Seq[BuildInfoKey](version, BuildInfoKey(cliClasspath)),

--- a/build.sbt
+++ b/build.sbt
@@ -178,7 +178,6 @@ lazy val plugin = project.in(file("plugin"))
     scriptedBufferLog := false,
     scriptedLaunchOpts += s"-Dplugin.version=${version.value}",
     libraryDependencies ++= Seq(
-      "dev.dirs" % "directories" % "26",
       ("io.get-coursier" %% "coursier" % "2.1.24").cross(CrossVersion.for3Use2_13)
         .exclude("org.scala-lang.modules", "scala-xml_2.13"),
     ),

--- a/build.sbt
+++ b/build.sbt
@@ -45,6 +45,7 @@ ThisBuild / githubWorkflowJavaVersions := javaVersions
 ThisBuild / githubWorkflowArtifactUpload := false
 ThisBuild / githubWorkflowBuildMatrixFailFast := Some(false)
 ThisBuild / githubWorkflowTargetBranches := Seq("main", "native-image")
+ThisBuild / githubWorkflowTargetTags := Seq("v*")
 ThisBuild / githubWorkflowPublishTargetBranches := Seq()
 
 def isJava(v: Int) = s"matrix.java == '${javaVersions.find(_.version == v.toString).get.render}'"

--- a/plugin/src/main/scala/bondlink/FindUnusedPlugin.scala
+++ b/plugin/src/main/scala/bondlink/FindUnusedPlugin.scala
@@ -3,34 +3,22 @@ package bondlink
 import coursier.Fetch
 import coursier.core.*
 import coursier.maven.MavenRepository
-import dev.dirs.BaseDirectories
-import java.io.{FileOutputStream, PrintWriter, StringWriter}
-import java.net.URI
-import java.nio.channels.Channels
+import java.io.{PrintWriter, StringWriter}
 import sbt.*
 import sbt.internal.util.complete.*
 import sbt.internal.util.complete.Parsers.*
 import sbt.Keys.*
 import sbt.plugins.JvmPlugin
-import scala.sys.process.*
 
 object FindUnusedPlugin extends AutoPlugin {
-  sealed trait CliRunnable
-  case class CliBinary(path: File) extends CliRunnable
-  case class CliClasspath(cp: Seq[File]) extends CliRunnable
-
   object autoImport {
     val findUnused = settingKey[Unit]("Find unused")
 
-    val findUnusedCliBinaryDownload = taskKey[CliRunnable]("Find unused CLI binary download")
+    val findUnusedCliDownload = taskKey[Seq[File]]("Find unused CLI download")
 
-    val findUnusedCliCoursierDownload = taskKey[CliClasspath]("Find unused CLI coursier download")
+    val findUnusedCliClasspath = taskKey[Seq[File]]("Find unused CLI classpath")
 
-    val findUnusedCliRunnable = taskKey[CliRunnable]("Find unused CLI runnable")
-
-    val findUnusedCommandOptions = taskKey[(CliRunnable, Seq[String])]("Find unused command options")
-
-    val findUnusedUseCoursier = settingKey[Boolean]("Find unused use coursier")
+    val findUnusedCommandOptions = taskKey[(ForkOptions, Seq[String], Seq[String])]("Find unused command options")
 
     val findUnusedUseLocalClasspath = settingKey[Boolean]("Find unused use local classpath")
 
@@ -59,11 +47,9 @@ object FindUnusedPlugin extends AutoPlugin {
 
   override lazy val globalSettings: Seq[Setting[?]] = Def.settings(
     findUnused / javaOptions := Seq.empty,
-    findUnusedCliBinaryDownload := findUnusedCliBinaryDownloadTask.value,
-    findUnusedCliCoursierDownload := findUnusedCliCoursierDownloadTask.value,
-    findUnusedCliRunnable := findUnusedCliRunnableTask.value,
+    findUnusedCliDownload := findUnusedCliDownloadTask.value,
+    findUnusedCliClasspath := findUnusedCliClasspathTask.value,
     findUnusedCommandOptions := findUnusedCommandOptionsTask.value,
-    findUnusedUseCoursier := false,
     findUnusedUseLocalClasspath := false,
     findUnusedStoreProjectClasspaths := findUnusedStoreProjectClasspathsTask.evaluated,
     findUnusedPackages := Seq.empty,
@@ -72,7 +58,7 @@ object FindUnusedPlugin extends AutoPlugin {
   )
 
   // https://stackoverflow.com/a/39868021/2163024
-  private def autoClose0[A <: AutoCloseable, B](a: A)(f: A => B): B = {
+  private def autoClose[A <: AutoCloseable, B](a: A)(f: A => B): B = {
     var err: Throwable = null
     try { f(a) }
     catch {
@@ -97,8 +83,8 @@ object FindUnusedPlugin extends AutoPlugin {
   private def runLogged[A](log: Logger, f: () => A): A =
     scala.util.Try(f()).fold(
       e => {
-        autoClose0(new StringWriter())(sw =>
-          autoClose0(new PrintWriter(sw)) { pw =>
+        autoClose(new StringWriter())(sw =>
+          autoClose(new PrintWriter(sw)) { pw =>
             e.printStackTrace(pw)
             log.error(sw.toString)
           }
@@ -108,80 +94,19 @@ object FindUnusedPlugin extends AutoPlugin {
       identity,
     )
 
-  private def autoClose[A <: AutoCloseable, B](log: Logger, get: () => A)(f: A => B): B =
-    autoClose0(runLogged(log, get))(f)
+  private lazy val findUnusedCliDownloadTask = Def.task {
+    val log = streams.value.log
 
-  private def sysProp(name: String): Option[String] = Option(System.getProperty(name)).map(_.toLowerCase)
-
-  private def isLinux(os: String): Boolean = os.contains("linux")
-  private def isMac(os: String): Boolean = os.contains("mac")
-  private def isWindows(os: String): Boolean = os.contains("windows")
-
-  private def isARM(arch: String): Boolean = arch.contains("aarch64") || arch.contains("arm64")
-  private def isX64(arch: String): Boolean = arch.contains("x86_64") || arch.contains("amd64")
-
-  private def coursierDownload(log: Logger): CliClasspath = {
     log.info("Fetching find-unused CLI with coursier")
+
     val dep = Dependency(Module(Organization("bondlink"), ModuleName("find-unused-cli_3"), Map.empty), BuildInfo.version)
     val repos = Seq(MavenRepository("https://raw.githubusercontent.com/mblink/maven-repo/main"))
-    val cp = runLogged(log, () => Fetch().withRepositories(repos).addDependencies(dep).run())
-    CliClasspath(cp)
+    runLogged(log, () => Fetch().withRepositories(repos).addDependencies(dep).run())
   }
 
-  private lazy val findUnusedCliBinaryDownloadTask = Def.task {
-    val log = streams.value.log
-    val cliBinaryName = (sysProp("os.name"), sysProp("os.arch")) match {
-      case (Some(os), Some(arch)) if isLinux(os) && isARM(arch) => Some("find-unused-linux-arm")
-      case (Some(os), Some(arch)) if isLinux(os) && isX64(arch) => Some("find-unused-linux")
-      case (Some(os), Some(arch)) if isMac(os) && isARM(arch) => Some("find-unused-mac-arm")
-      case (Some(os), Some(arch)) if isMac(os) && isX64(arch) => Some("find-unused-mac")
-      case (Some(os), _) if isWindows(os) => Some("find-unused-windows.exe")
-      case _ => None
-    }
-
-    cliBinaryName match {
-      case Some(bin) =>
-        val binDir = file(BaseDirectories.get.cacheDir) / "find-unused" / BuildInfo.version
-        val binPath = binDir / bin
-        val binPathTgz = binDir / s"$bin.tar.gz"
-
-        log.info(s"Checking for binary $binPath")
-
-        if (!binPath.exists) {
-          val url = s"https://github.com/mblink/find-unused/releases/download/v${BuildInfo.version}/$bin.tar.gz"
-          log.info(s"Binary $binPath does not exist, downloading from $url...")
-
-          binDir.mkdirs
-
-          autoClose(log, () => Channels.newChannel(new URI(url).toURL.openStream))(channel =>
-            autoClose(log, () => new FileOutputStream(binPathTgz))(output =>
-              output.getChannel.transferFrom(channel, 0, Long.MaxValue)
-            )
-          )
-
-          log.info(s"Extracting $binPathTgz to $binPath")
-
-          Process(Seq("tar", "-xzf", s"$bin.tar.gz"), cwd = Some(binDir)).! match {
-            case 0 => ()
-            case code => throw new MessageOnlyException(s"Failed to extract binary (exit code $code)")
-          }
-        }
-
-        CliBinary(binPath)
-
-      case None =>
-        coursierDownload(log)
-    }
-  }
-
-  private lazy val findUnusedCliCoursierDownloadTask = Def.task {
-    coursierDownload(streams.value.log)
-  }
-
-  private lazy val findUnusedCliRunnableTask = Def.taskDyn {
-    if (findUnusedUseLocalClasspath.value) Def.task[CliRunnable](CliClasspath(BuildInfo.cliClasspath))
-    else if (findUnusedUseCoursier.value) Def.task[CliRunnable](findUnusedCliCoursierDownload.value)
-    else Def.task(findUnusedCliBinaryDownload.value)
+  private lazy val findUnusedCliClasspathTask = Def.taskDyn {
+    if (findUnusedUseLocalClasspath.value) Def.task[Seq[File]](BuildInfo.cliClasspath)
+    else Def.task(findUnusedCliDownload.value)
   }
 
   private val scalaVersionParser = {
@@ -231,7 +156,15 @@ object FindUnusedPlugin extends AutoPlugin {
   }
 
   private lazy val findUnusedCommandOptionsTask = Def.task {
-    val cliRunnable = findUnusedCliRunnable.value
+    val forkOpts = ForkOptions()
+      .withJavaHome(javaHome.value)
+      .withOutputStrategy(outputStrategy.value)
+      .withConnectInput(false)
+      .withRunJVMOptions((findUnused / javaOptions).value.toVector)
+
+    val cliClasspath = findUnusedCliClasspath.value
+    val mainClass = "bondlink.FindUnusedCli"
+    val scalaOpts = List("-classpath", Path.makeString(cliClasspath), mainClass)
 
     @annotation.tailrec
     def runCommand(command: String, state: State): State = {
@@ -256,27 +189,13 @@ object FindUnusedPlugin extends AutoPlugin {
 
     val cliOpts = projClasspath.flatMap(Seq("-c", _)) ++ projPackages.flatMap(Seq("-p", _))
 
-    (cliRunnable, cliOpts)
+    (forkOpts, scalaOpts, cliOpts)
   }
 
   private lazy val findUnusedGivensTask = Def.task {
-    val exitCode = findUnusedCommandOptions.value match {
-      case (CliBinary(cliBinary), cliOpts) =>
-        (cliBinary.toString +: "givens" +: cliOpts).!
+    val (forkOpts, scalaOpts, cliOpts) = findUnusedCommandOptions.value
 
-      case (CliClasspath(cliClasspath), cliOpts) =>
-        val forkOpts = ForkOptions()
-          .withJavaHome(javaHome.value)
-          .withOutputStrategy(outputStrategy.value)
-          .withConnectInput(false)
-          .withRunJVMOptions((findUnused / javaOptions).value.toVector)
-
-        val scalaOpts = List("-classpath", Path.makeString(cliClasspath), "bondlink.FindUnusedCli")
-
-        Fork.java.fork(forkOpts, scalaOpts ++ List("givens") ++ cliOpts).exitValue()
-    }
-
-    exitCode match {
+    Fork.java.fork(forkOpts, scalaOpts ++ List("givens") ++ cliOpts).exitValue() match {
       case 0 => ()
       case 1 => throw new MessageOnlyException("findUnusedGivens failed, see output above")
     }

--- a/plugin/src/main/scala/bondlink/FindUnusedPlugin.scala
+++ b/plugin/src/main/scala/bondlink/FindUnusedPlugin.scala
@@ -3,21 +3,34 @@ package bondlink
 import coursier.Fetch
 import coursier.core.*
 import coursier.maven.MavenRepository
+import dev.dirs.BaseDirectories
+import java.io.FileOutputStream
+import java.net.URI
+import java.nio.channels.Channels
 import sbt.*
 import sbt.internal.util.complete.*
 import sbt.internal.util.complete.Parsers.*
 import sbt.Keys.*
 import sbt.plugins.JvmPlugin
+import scala.sys.process.*
 
 object FindUnusedPlugin extends AutoPlugin {
+  sealed trait CliRunnable
+  case class CliBinary(path: File) extends CliRunnable
+  case class CliClasspath(cp: Seq[File]) extends CliRunnable
+
   object autoImport {
     val findUnused = settingKey[Unit]("Find unused")
 
-    val findUnusedCliDownload = taskKey[Seq[File]]("Find unused CLI download")
+    val findUnusedCliBinaryDownload = taskKey[CliRunnable]("Find unused CLI binary download")
 
-    val findUnusedCliClasspath = taskKey[Seq[File]]("Find unused CLI classpath")
+    val findUnusedCliCoursierDownload = taskKey[CliClasspath]("Find unused CLI coursier download")
 
-    val findUnusedCommandOptions = taskKey[(ForkOptions, Seq[String], Seq[String])]("Find unused command options")
+    val findUnusedCliRunnable = taskKey[CliRunnable]("Find unused CLI runnable")
+
+    val findUnusedCommandOptions = taskKey[(CliRunnable, Seq[String])]("Find unused command options")
+
+    val findUnusedUseCoursier = settingKey[Boolean]("Find unused use coursier")
 
     val findUnusedUseLocalClasspath = settingKey[Boolean]("Find unused use local classpath")
 
@@ -41,30 +54,115 @@ object FindUnusedPlugin extends AutoPlugin {
   private val findUnusedStoreAllProjectClasspaths = "findUnusedStoreAllProjectClasspaths"
 
   private lazy val commands = Seq(
-    Command.command(findUnusedStoreAllProjectClasspaths)(storeAllProjectClasspaths),
+    Command.command(findUnusedStoreAllProjectClasspaths)(findUnusedStoreAllProjectClasspaths),
   )
 
   override lazy val globalSettings: Seq[Setting[?]] = Def.settings(
     findUnused / javaOptions := Seq.empty,
-    findUnusedCliDownload := findUnusedCliDownloadTask.value,
-    findUnusedCliClasspath := findUnusedCliClasspathTask.value,
+    findUnusedCliBinaryDownload := findUnusedCliBinaryDownloadTask.value,
+    findUnusedCliCoursierDownload := findUnusedCliCoursierDownloadTask.value,
+    findUnusedCliRunnable := findUnusedCliRunnableTask.value,
     findUnusedCommandOptions := findUnusedCommandOptionsTask.value,
+    findUnusedUseCoursier := false,
     findUnusedUseLocalClasspath := false,
-    findUnusedStoreProjectClasspaths := storeProjectClasspathsTask.evaluated,
+    findUnusedStoreProjectClasspaths := findUnusedStoreProjectClasspathsTask.evaluated,
     findUnusedPackages := Seq.empty,
     findUnusedGivens := findUnusedGivensTask.value,
     Keys.commands ++= commands,
   )
 
-  private lazy val findUnusedCliDownloadTask = Def.task {
-    val dep = Dependency(Module(Organization("bondlink"), ModuleName("find-unused-cli_3"), Map.empty), BuildInfo.version)
-    val repos = Seq(MavenRepository("https://raw.githubusercontent.com/mblink/maven-repo/main"))
-    Fetch().withRepositories(repos).addDependencies(dep).run()
+  // https://stackoverflow.com/a/39868021/2163024
+  private def autoClose[A <: AutoCloseable, B](a: A)(f: A => B): B = {
+    var err: Throwable = null
+    try { f(a) }
+    catch {
+      case t: Throwable =>
+        err = t
+        throw t
+    } finally {
+      if (err != null)
+        try { a.close() }
+        catch {
+          case t: Throwable =>
+            err.addSuppressed(t)
+            throw t
+        }
+      else
+        a.close()
+    }
   }
 
-  private lazy val findUnusedCliClasspathTask = Def.taskDyn {
-    if (findUnusedUseLocalClasspath.value) Def.task[Seq[File]](BuildInfo.cliClasspath)
-    else Def.task(findUnusedCliDownload.value)
+  private def sysProp(name: String): Option[String] = Option(System.getProperty(name)).map(_.toLowerCase)
+
+  private def isLinux(os: String): Boolean = os.contains("linux")
+  private def isMac(os: String): Boolean = os.contains("mac")
+  private def isWindows(os: String): Boolean = os.contains("windows")
+
+  private def isARM(arch: String): Boolean = arch.contains("aarch64") || arch.contains("arm64")
+  private def isX64(arch: String): Boolean = arch.contains("x86_64") || arch.contains("amd64")
+
+  private def coursierDownload(log: Logger): CliClasspath = {
+    log.info("Fetching find-unused CLI with coursier")
+    val dep = Dependency(Module(Organization("bondlink"), ModuleName("find-unused-cli_3"), Map.empty), BuildInfo.version)
+    val repos = Seq(MavenRepository("https://raw.githubusercontent.com/mblink/maven-repo/main"))
+    val cp = Fetch().withRepositories(repos).addDependencies(dep).run()
+    CliClasspath(cp)
+  }
+
+  private lazy val findUnusedCliBinaryDownloadTask = Def.task {
+    val log = streams.value.log
+    val cliBinaryName = (sysProp("os.name"), sysProp("os.arch")) match {
+      case (Some(os), Some(arch)) if isLinux(os) && isARM(arch) => Some("find-unused-linux-arm")
+      case (Some(os), Some(arch)) if isLinux(os) && isX64(arch) => Some("find-unused-linux")
+      case (Some(os), Some(arch)) if isMac(os) && isARM(arch) => Some("find-unused-mac-arm")
+      case (Some(os), Some(arch)) if isMac(os) && isX64(arch) => Some("find-unused-mac")
+      case (Some(os), _) if isWindows(os) => Some("find-unused-windows.exe")
+      case _ => None
+    }
+
+    cliBinaryName match {
+      case Some(bin) =>
+        val binDir = file(BaseDirectories.get.cacheDir) / "find-unused" / BuildInfo.version
+        val binPath = binDir / bin
+        val binPathTgz = binDir / s"$bin.tar.gz"
+
+        log.info(s"Checking for binary $binPath")
+
+        if (!binPath.exists) {
+          val url = s"https://github.com/mblink/find-unused/releases/download/v${BuildInfo.version}/$bin.tar.gz"
+          log.info(s"Binary $binPath does not exist, downloading from $url...")
+
+          binDir.mkdirs
+
+          autoClose(Channels.newChannel(new URI(url).toURL.openStream))(channel =>
+            autoClose(new FileOutputStream(binPathTgz))(output =>
+              output.getChannel.transferFrom(channel, 0, Long.MaxValue)
+            )
+          )
+
+          log.info(s"Extracting $binPathTgz to $binPath")
+
+          Seq("tar", "-xzf", s"$bin.tar.gz").! match {
+            case 0 => ()
+            case code => throw new MessageOnlyException(s"Failed to extract binary (exit code $code)")
+          }
+        }
+
+        CliBinary(binPath)
+
+      case None =>
+        coursierDownload(log)
+    }
+  }
+
+  private lazy val findUnusedCliCoursierDownloadTask = Def.task {
+    coursierDownload(streams.value.log)
+  }
+
+  private lazy val findUnusedCliRunnableTask = Def.taskDyn {
+    if (findUnusedUseLocalClasspath.value) Def.task[CliRunnable](CliClasspath(BuildInfo.cliClasspath))
+    else if (findUnusedUseCoursier.value) Def.task[CliRunnable](findUnusedCliCoursierDownload.value)
+    else Def.task(findUnusedCliBinaryDownload.value)
   }
 
   private val scalaVersionParser = {
@@ -75,7 +173,7 @@ object FindUnusedPlugin extends AutoPlugin {
     )
   }
 
-  private lazy val storeProjectClasspathsTask = Def.inputTaskDyn {
+  private lazy val findUnusedStoreProjectClasspathsTask = Def.inputTaskDyn {
     val scalaVersionInput = (Parsers.Space ~> scalaVersionParser).parsed
     val state = Keys.state.value
     val projectRefs = state.attributes(findUnusedProjectsKey).filter(p => state.setting(p / scalaVersion) == scalaVersionInput)
@@ -95,7 +193,7 @@ object FindUnusedPlugin extends AutoPlugin {
     }
   }
 
-  private def storeAllProjectClasspaths(state: State): State = {
+  private def findUnusedStoreAllProjectClasspaths(state: State): State = {
     val loadedBuild = state.setting(Keys.loadedBuild)
     // all project refs that have a Scala version
     val projectRefs = loadedBuild.allProjectRefs.map(_._1).filter(p => state.getSetting(p / scalaVersion).isDefined)
@@ -114,15 +212,7 @@ object FindUnusedPlugin extends AutoPlugin {
   }
 
   private lazy val findUnusedCommandOptionsTask = Def.task {
-    val forkOpts = ForkOptions()
-      .withJavaHome(javaHome.value)
-      .withOutputStrategy(outputStrategy.value)
-      .withConnectInput(false)
-      .withRunJVMOptions((findUnused / javaOptions).value.toVector)
-
-    val cliClasspath = findUnusedCliClasspath.value
-    val mainClass = "bondlink.FindUnusedCli"
-    val scalaOpts = List("-classpath", Path.makeString(cliClasspath), mainClass)
+    val cliRunnable = findUnusedCliRunnable.value
 
     @annotation.tailrec
     def runCommand(command: String, state: State): State = {
@@ -147,13 +237,27 @@ object FindUnusedPlugin extends AutoPlugin {
 
     val cliOpts = projClasspath.flatMap(Seq("-c", _)) ++ projPackages.flatMap(Seq("-p", _))
 
-    (forkOpts, scalaOpts, cliOpts)
+    (cliRunnable, cliOpts)
   }
 
   private lazy val findUnusedGivensTask = Def.task {
-    val (forkOpts, scalaOpts, cliOpts) = findUnusedCommandOptions.value
+    val exitCode = findUnusedCommandOptions.value match {
+      case (CliBinary(cliBinary), cliOpts) =>
+        (cliBinary.toString +: cliOpts).!
 
-    Fork.java.fork(forkOpts, scalaOpts ++ List("givens") ++ cliOpts).exitValue() match {
+      case (CliClasspath(cliClasspath), cliOpts) =>
+        val forkOpts = ForkOptions()
+          .withJavaHome(javaHome.value)
+          .withOutputStrategy(outputStrategy.value)
+          .withConnectInput(false)
+          .withRunJVMOptions((findUnused / javaOptions).value.toVector)
+
+        val scalaOpts = List("-classpath", Path.makeString(cliClasspath), "bondlink.FindUnusedCli")
+
+        Fork.java.fork(forkOpts, scalaOpts ++ List("givens") ++ cliOpts).exitValue()
+    }
+
+    exitCode match {
       case 0 => ()
       case 1 => throw new MessageOnlyException("findUnusedGivens failed, see output above")
     }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,10 +1,10 @@
 lazy val sbtGitHubActions = RootProject(uri(s"https://github.com/sbt/sbt-github-actions.git#8db8710ab7c69e452edd501d54eb4e12b3b2c03a"))
 dependsOn(sbtGitHubActions)
 
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "2.3.1")
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0")
 // addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.24.0")
-addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")
 
 resolvers += "bondlink-maven-repo" at "https://raw.githubusercontent.com/mblink/maven-repo/main"

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,6 +1,9 @@
+lazy val sbtGitHubActions = RootProject(uri(s"https://github.com/sbt/sbt-github-actions.git#8db8710ab7c69e452edd501d54eb4e12b3b2c03a"))
+dependsOn(sbtGitHubActions)
+
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.13.1")
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.0")
-addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.24.0")
+// addSbtPlugin("com.github.sbt" % "sbt-github-actions" % "0.24.0")
 addSbtPlugin("com.github.sbt" % "sbt-native-packager" % "1.11.1")
 addSbtPlugin("org.typelevel" % "sbt-tpolecat" % "0.5.2")
 


### PR DESCRIPTION
Uses sbt-assembly to build a far JAR of the CLI and updates the GitHub actions workflows to draft a release in GitHub with that JAR as an asset on pushes to tags matching `v*`

The commit history here also shows an attempt to use GraalVM and `native-image` to produce CLI binaries. Producing the binaries works properly, but running them has issues, specifically [getting the JRT file system here](https://github.com/mblink/find-unused/blob/8127932fecd7b1a8ad10367d6359b711af8752a4/core/src/main/scala/bondlink/FindUnused.scala#L18) doesn't work.