### PR TITLE
Account for exports that encompass multiple terms

### DIFF
--- a/core/src/main/scala/bl/unused/References.scala
+++ b/core/src/main/scala/bl/unused/References.scala
@@ -2,6 +2,7 @@ package bl.unused
 
 import cats.Monoid
 import cats.syntax.applicative.*
+import cats.syntax.foldable.*
 import cats.syntax.semigroup.*
 import tastyquery.Contexts.Context
 import tastyquery.Symbols.*
@@ -83,8 +84,7 @@ object References {
           - This covers cases where an export is only used as a value, not also as a type
       */
       case t: TermSymbol if t.isExport =>
-        Symbols.matchingTermSymbol(t).fold(empty)(fromSymbol(_, mk, true)) |+|
-          Symbols.matchingTypeSymbol(t).fold(empty)(fromSymbol(_, mk, true))
+        Symbols.allMatchingSymbols(t).foldMap(fromSymbol(_, mk, true))
 
       /*
       If sym is a type member and there's a matching term symbol that's an exported term, consider the term used
@@ -92,7 +92,7 @@ object References {
       This covers cases where an export is only used as a type and the companion object isn't used
       */
       case t: TypeMemberSymbol =>
-        Symbols.matchingTermSymbol(t).filter(_.isExport).fold(empty)(fromSymbol(_, mk, true))
+        Symbols.allMatchingSymbols(t).collect { case t: TermSymbol if t.isExport => t }.foldMap(fromSymbol(_, mk, true))
 
       case _ => empty
     })

--- a/plugin/src/sbt-test/find-unused/double-export/build.sbt
+++ b/plugin/src/sbt-test/find-unused/double-export/build.sbt
@@ -1,0 +1,9 @@
+Global / findUnusedUseLocalClasspath := true
+Global / findUnusedUseRootDirectory := false
+Global / findUnusedPackages += "bl.unused"
+Global / findUnusedOutputFile := Some((ThisBuild / baseDirectory).value / "output" / "actual.txt")
+
+lazy val root = project.in(file(".")).settings(
+  version := "0.1.0-SNAPSHOT",
+  scalaVersion := "3.7.1",
+)

--- a/plugin/src/sbt-test/find-unused/double-export/output/expected.txt
+++ b/plugin/src/sbt-test/find-unused/double-export/output/expected.txt
@@ -1,0 +1,1 @@
+No unused terms found

--- a/plugin/src/sbt-test/find-unused/double-export/project/plugins.sbt
+++ b/plugin/src/sbt-test/find-unused/double-export/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("bondlink" % "find-unused-plugin" % sys.props("plugin.version"))

--- a/plugin/src/sbt-test/find-unused/double-export/src/main/scala/bl/unused/Test.scala
+++ b/plugin/src/sbt-test/find-unused/double-export/src/main/scala/bl/unused/Test.scala
@@ -1,0 +1,19 @@
+package bl.unused
+
+object types {
+  opaque type ->>[K, V] = V
+
+  def label[K]: [V] => V => (K ->> V) = [V] => v => v
+
+  extension[K, V](@annotation.nowarn("msg=unused") kv: K ->> V) def label(using k: ValueOf[K]): K = k.value
+}
+
+object foo {
+  // The `label` extension method is not used anywhere, but the standard `label` method is used
+  // This test confirms that both are considered used because of that
+  export types.{->>, label}
+}
+
+import foo.*
+
+@annotation.nowarn("msg=unused") val i: "i" ->> Int = label["i"](1)

--- a/plugin/src/sbt-test/find-unused/double-export/test
+++ b/plugin/src/sbt-test/find-unused/double-export/test
@@ -1,0 +1,2 @@
+> findUnusedAll
+$ must-mirror output/expected.txt output/actual.txt


### PR DESCRIPTION
See the code and comment in `plugin/src/sbt-test/find-unused/double-export/src/main/scala/bl/unused/Test.scala` for an explanation of what this covers that wasn't handled before