### PR TITLE
Only consider symbols in the given packages

### DIFF
--- a/core/src/main/scala/bl/unused/FindUnused.scala
+++ b/core/src/main/scala/bl/unused/FindUnused.scala
@@ -18,7 +18,8 @@ object FindUnused {
       // `implicit val` instead of `given` so it's initialized eagerly for logging/timing purposes
       implicit val ctx: Context = Context.initialize(ClasspathLoaders.read(javaModules ::: classpath.toList))
 
-      val env = Env(debug, rootDirectory, packages, symbolIsValid)
+      val pkgSyms = packages.map(ctx.findPackage).toSet
+      val env = Env(debug, rootDirectory, packages, sym => symbolIsValid(sym) && Symbols.isInPackage(pkgSyms)(sym))
 
       packages.foldMap { p =>
         println(s"[find-unused] Analyzing package $p")

--- a/core/src/main/scala/bl/unused/Symbols.scala
+++ b/core/src/main/scala/bl/unused/Symbols.scala
@@ -35,6 +35,12 @@ object Symbols {
   def isValidDefinition(sym: Symbol): Boolean =
     !isSynthetic(sym) && !isConstructor(sym) && !isDefaultParam(sym)
 
+  def isInPackage(pkgSyms: Set[PackageSymbol])(sym: Symbol): Boolean =
+    sym match {
+      case p: PackageSymbol => pkgSyms.contains(p) || Option(p.owner).exists(isInPackage(pkgSyms))
+      case _ => Option(sym.owner).exists(isInPackage(pkgSyms))
+    }
+
   def name(sym: Symbol): String =
     (Option(sym.owner) match {
       case Some(owner: PackageSymbol) => s"${owner.displayFullName}.${sym.name}"


### PR DESCRIPTION
Uses the packages given on the command line (or provided through the sbt plugin) to limit which symbols are considered valid when adding to `References`