### PR TITLE
Fix case classes never being reported unused

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,8 +68,13 @@ jobs:
       - name: Check that workflows are up to date
         run: sbt '++ ${{ matrix.scala }}' githubWorkflowCheck
 
-      - name: Test
+      - name: scripted
+        if: matrix.scala == '2.12.20'
         run: sbt '++ ${{ matrix.scala }}' test scripted
+
+      - name: compile
+        if: matrix.scala == '3.6.4' || matrix.scala == '3.7.1'
+        run: sbt '++ ${{ matrix.scala }}' Test/compile
 
       - name: Build CLI
         if: matrix.java == 'temurin@21' && matrix.scala == '3.7.1' && github.event_name == 'push'

--- a/build.sbt
+++ b/build.sbt
@@ -138,7 +138,7 @@ lazy val core = project.in(file("core"))
   .settings(
     name := "find-unused-core",
     libraryDependencies ++= Seq(
-      "com.lihaoyi" %% "pprint" % "0.9.0",
+      "com.lihaoyi" %% "pprint" % "0.9.3",
       "org.typelevel" %% "cats-core" % "2.13.0",
     ),
   )

--- a/build.sbt
+++ b/build.sbt
@@ -45,7 +45,8 @@ def isScala(v: String) = s"matrix.scala == '$v'"
 val shouldBuildCLI = isJava(21) ++ " && " ++ isScala(scala37) ++ " && github.event_name == 'push'"
 
 ThisBuild / githubWorkflowBuild := Seq(
-  WorkflowStep.Sbt(List("test", "scripted"), name = Some("Test")),
+  WorkflowStep.Sbt(List("test", "scripted"), name = Some("scripted"), cond = Some(isScala(scala2))),
+  WorkflowStep.Sbt(List("Test/compile"), name = Some("compile"), cond = Some(isScala(scala36) ++ " || " ++ isScala(scala37))),
   WorkflowStep.Sbt(
     List("cli/assembly"),
     name = Some("Build CLI"),

--- a/build.sbt
+++ b/build.sbt
@@ -129,15 +129,11 @@ lazy val core = project.in(file("core"))
   .settings(commonSettings)
   .settings(publishSettings)
   .settings(
-    if (tastyQueryDev) Seq()
-    else Seq(
-      resolvers += "bondlink-maven-repo" at "https://maven.bondlink-cdn.com",
-      libraryDependencies += "bondlink" %% "tasty-query" % "1.6.0",
-    )
-  )
-  .settings(
     name := "find-unused-core",
-    libraryDependencies ++= Seq(
+    libraryDependencies ++= (
+      if (tastyQueryDev) Seq()
+      else Seq("ch.epfl.scala" %% "tasty-query" % "1.6.1")
+    ) ++ Seq(
       "com.lihaoyi" %% "pprint" % "0.9.3",
       "org.typelevel" %% "cats-core" % "2.13.0",
     ),

--- a/core/src/main/scala/bl/unused/Symbols.scala
+++ b/core/src/main/scala/bl/unused/Symbols.scala
@@ -24,6 +24,9 @@ object Symbols {
     else
       None
 
+  def isSyntheticMemberOfCaseClass(cls: ClassSymbol, sym: Symbol)(using ctx: Context): Boolean =
+    syntheticMemberOfCaseClass(sym).fold(false)(_ == cls)
+
   def isConstructor(sym: Symbol): Boolean = sym.name == nme.Constructor
 
   def isDefaultParam(sym: Symbol): Boolean =

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.11.2
+sbt.version=1.11.3


### PR DESCRIPTION
This fixes an issue where a case class with at least one field is always considered used. It happens because `def productElement`, a synthetic method, refers to `def _1`, another synthetic method, which refers to the case class itself.

The code was already setup so that a reference to a case class from a synthetic method would not cause the case class to be considered used -- it works by building up a `usedProxy` map where the keys are the symbols of the synthetic methods and the values are the symbols of the case classes. At the end of the world, if any of the symbols that appear in the keys of `usedProxy` have been used, then we consider the values used as well.

However this didn't account for cases where the `usedProxy` keys (the synthetic methods) are used by other synthetic methods. Since this happens with `productElement` and `_1`, case classes were never reported unused.