### PR TITLE
Better override handling

### DIFF
--- a/core/src/main/scala/bl/unused/Symbols.scala
+++ b/core/src/main/scala/bl/unused/Symbols.scala
@@ -451,8 +451,7 @@ object Symbols {
                   case TypeMemberDefinition.AbstractType(bounds) =>
                     Types.typeBoundsTypes(bounds).flatMap(Types.symbols).foldMap(References.fromSymbol(_, References.used))
                   case TypeMemberDefinition.OpaqueTypeAlias(bounds, tpe) =>
-                    Types.typeBoundsTypes(bounds).flatMap(Types.symbols).foldMap(References.fromSymbol(_, References.used)) |+|
-                      Types.symbols(tpe).toList.foldMap(References.fromSymbol(_, References.used))
+                    (tpe :: Types.typeBoundsTypes(bounds)).flatMap(Types.symbols).foldMap(References.fromSymbol(_, References.used))
                 })
 
             case _: (ClassTypeParamSymbol | LocalTypeParamSymbol) => References.empty

--- a/core/src/main/scala/bl/unused/Trees.scala
+++ b/core/src/main/scala/bl/unused/Trees.scala
@@ -83,10 +83,9 @@ object Trees {
         case Export(expr, selectors) => references(expr) |+| referencesL(selectors)
         case ExprPattern(expr) => references(expr)
         case i @ Ident(_) =>
-          Symbols.getFromIdent(i).toList.foldMap { sym =>
-            Symbols.withStaticOwners(sym).toList.foldMap(References.fromSymbol(_, References.used)) |+|
-              References.usedProxy(sym, Symbols.superParamSymbols(sym))
-          }
+          Symbols.getFromIdent(i).toList.foldMap(
+            Symbols.withStaticOwners(_).toList.foldMap(References.fromSymbol(_, References.used))
+          )
         case If(cond, thenPart, elsePart) => references(cond) |+| references(thenPart) |+| references(elsePart)
         case Import(expr, selectors) => references(expr) |+| referencesL(selectors)
         case ImportIdent(_) => References.empty

--- a/core/src/main/scala/bl/unused/Trees.scala
+++ b/core/src/main/scala/bl/unused/Trees.scala
@@ -1,5 +1,7 @@
 package bl.unused
 
+import cats.syntax.apply.*
+import cats.syntax.either.*
 import cats.syntax.foldable.*
 import cats.syntax.semigroup.*
 import tastyquery.Contexts.*
@@ -37,9 +39,24 @@ object Trees {
       case Some(cls) =>
         EnvR((env, syms) =>
           refs.run(env.copy(symbolIsValid = s => env.symbolIsValid(s) && !Symbols.isSyntheticMemberOfCaseClass(cls, s)), syms)
-        ).map(_.removeUsed(cls).addUsedProxy(sym, cls))
+        ).flatMap(_.removeUsed(cls).addUsedProxy(sym, Set(cls)))
       case None => refs
     }
+
+  /**
+   * If this `Lambda` represents an implementation of a trait/class using single abstract method (SAM) syntax, we consider
+   * the parameters of the method in the trait/class used when the parameters of the lambda are used.
+   */
+  private def singleAbstractMethodReferences(l: Lambda)(using ctx: Context): EnvR[References] = {
+    val thisParamsO = Some(l.meth.symbol).collect { case t: TermSymbol => t.paramSymss.flatMap(_.merge) }
+    val superParamsO = Either.catchNonFatal(l.samClassSymbol).toOption
+      .map(_.declarations.collect { case t: TermSymbol if t.isMethod && t.isAbstractMember && !Symbols.isConstructor(t) => t })
+      .collect { case t :: Nil => t.paramSymss.flatMap(_.merge) }
+
+    (thisParamsO, superParamsO).tupled.fold(References.empty)((thisParams, superParams) =>
+      References.usedProxy(thisParams.lazyZip(superParams).map((t, s) => (t, Set(s))).toMap)
+    )
+  }
 
   def references(tree: Tree)(using ctx: Context): EnvR[References] =
     EnvR.debug.flatMap { debug =>
@@ -66,9 +83,10 @@ object Trees {
         case Export(expr, selectors) => references(expr) |+| referencesL(selectors)
         case ExprPattern(expr) => references(expr)
         case i @ Ident(_) =>
-          Symbols.getFromIdent(i).toList.foldMap(
-            Symbols.withStaticOwners(_).toList.foldMap(References.fromSymbol(_, References.used))
-          )
+          Symbols.getFromIdent(i).toList.foldMap { sym =>
+            Symbols.withStaticOwners(sym).toList.foldMap(References.fromSymbol(_, References.used)) |+|
+              References.usedProxy(sym, Symbols.superParamSymbols(sym))
+          }
         case If(cond, thenPart, elsePart) => references(cond) |+| references(thenPart) |+| references(elsePart)
         case Import(expr, selectors) => references(expr) |+| referencesL(selectors)
         case ImportIdent(_) => References.empty
@@ -78,7 +96,7 @@ object Trees {
         case i @ InlinedTypeTree(caller, expansion) => Types.prefixReferences(i.toPrefix) |+| referencesO(caller) |+| references(expansion)
         case InlineIf(cond, thenPart, elsePart) => references(cond) |+| references(thenPart) |+| references(elsePart)
         case InlineMatch(selector, cases) => referencesO(selector) |+| referencesL(cases)
-        case Lambda(meth, tpt) => references(meth) |+| referencesO(tpt)
+        case l @ Lambda(meth, tpt) => references(meth) |+| referencesO(tpt) |+| singleAbstractMethodReferences(l)
         case Literal(_) => References.empty
         case Match(selector, cases) => references(selector) |+| referencesL(cases)
         case MatchTypeTree(bound, selector, cases) => references(bound) |+| references(selector) |+| referencesL(cases)


### PR DESCRIPTION
There were a few spots that were considering methods (and params of those methods) used because they were overrides of other method. During the initial build-out it was easier to just consider them used rather than try to determine the actual usage compared to usage of the super method.

This aims to make it better and to have fewer false negatives around overridden methods/params. It takes more advantage of the `References#usedProxy` field so we can say that a super method is used if the override is used and vice versa.